### PR TITLE
Detect host IP dynamically

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,13 @@
 export default {
   mode: "universal",
   /*
+   ** Detect host ip dynamically, listen at port 3000
+  */
+  server: {
+    port: 3000,
+    host: "0.0.0.0",
+  },
+  /*
    ** Headers of the page
    */
   head: {


### PR DESCRIPTION
Changes the webservice to listen to the IP of the host rather than
at localhost.

fixes yarl/finding-glams#3
Bug: T232074